### PR TITLE
Issue #6: RUNS v0.1 (APPROVED → RUN PLAN ARTIFACT) + /RUNS UI

### DIFF
--- a/app/runs/[run_id]/page.tsx
+++ b/app/runs/[run_id]/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { useStore } from '../../../lib/store';
+import EmptyState from '../../components/EmptyState';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export default function RunDetailPage() {
+  const { run_id } = useParams();
+  const { state } = useStore();
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+
+  const run = state.runs.find(r => r.run_id === run_id);
+  const proposal = run ? state.proposals.find(p => p.proposal_id === run.proposal_id) : null;
+
+  if (!state.isLoaded) {
+    return <div className="animate-pulse flex space-y-4 flex-col">
+      <div className="h-8 bg-gray-200 rounded w-1/3 mb-6"></div>
+      <div className="h-96 bg-gray-100 rounded-xl"></div>
+    </div>;
+  }
+
+  if (!run) {
+    return (
+      <div className="space-y-6">
+        <button 
+          onClick={() => router.back()}
+          className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back
+        </button>
+        <EmptyState
+          title="Run Plan Not Found"
+          description={`We couldn't find a run plan with ID "${run_id}". It may have been cleared or doesn't exist.`}
+        />
+      </div>
+    );
+  }
+
+  const handleCopyJson = () => {
+    navigator.clipboard.writeText(JSON.stringify(run, null, 2));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <button 
+          onClick={() => router.back()}
+          className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Runs
+        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={handleCopyJson}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            {copied ? (
+              <>
+                <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Copied!
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                </svg>
+                Copy JSON
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="p-8 border-b border-gray-100 bg-gray-50/50">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="bg-blue-600 text-white text-[10px] font-bold px-2 py-0.5 rounded uppercase tracking-wider">
+              {run.status}
+            </span>
+            <span className="text-gray-400 text-sm font-mono">
+              {run.run_id}
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">{run.plan.objective}</h1>
+          <p className="text-gray-500 text-sm">
+            Derived from Proposal:{' '}
+            <Link href={`/artifacts/${run.proposal_id}`} className="text-blue-600 hover:underline">
+              {proposal?.proposal.title || run.proposal_id}
+            </Link>
+          </p>
+        </div>
+
+        <div className="p-8 space-y-10">
+          {/* Execution Steps */}
+          <div>
+            <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wider mb-6 flex items-center gap-2">
+              <span className="w-6 h-6 bg-blue-100 text-blue-600 rounded flex items-center justify-center text-xs">01</span>
+              Execution Steps
+            </h3>
+            <div className="space-y-4 relative pl-3">
+              <div className="absolute left-0 top-0 bottom-0 w-px bg-gray-200"></div>
+              {run.plan.steps.map((step, i) => (
+                <div key={i} className="relative pl-8">
+                  <div className="absolute left-[-16.5px] top-1.5 w-2 h-2 rounded-full bg-white border-2 border-blue-600"></div>
+                  <p className="text-gray-700 text-sm leading-relaxed">{step}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+            {/* Inputs & Outputs */}
+            <div className="space-y-8">
+              <div>
+                <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3">Inputs Needed</h4>
+                <ul className="space-y-2">
+                  {run.plan.inputs_needed.map((item, i) => (
+                    <li key={i} className="text-sm text-gray-600 flex items-center gap-2">
+                      <span className="w-1 h-1 bg-gray-300 rounded-full"></span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3 text-green-600">Expected Outputs</h4>
+                <ul className="space-y-2">
+                  {run.plan.expected_outputs.map((item, i) => (
+                    <li key={i} className="text-sm text-gray-600 flex items-center gap-2">
+                      <span className="w-1 h-1 bg-green-300 rounded-full"></span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            {/* Risks & Rollback */}
+            <div className="space-y-8">
+              <div>
+                <h4 className="text-xs font-bold text-amber-600 uppercase tracking-wider mb-3">Risks</h4>
+                <ul className="space-y-2">
+                  {run.plan.risks.map((item, i) => (
+                    <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                      <span className="mt-1">⚠️</span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4 className="text-xs font-bold text-red-600 uppercase tracking-wider mb-3">Rollback Procedure</h4>
+                <ul className="space-y-2">
+                  {run.plan.rollback.map((item, i) => (
+                    <li key={i} className="text-sm text-gray-600 flex items-start gap-2">
+                      <span className="mt-1">🔄</span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-8 bg-gray-50 border-t border-gray-100 flex justify-between items-center text-xs text-gray-400">
+          <span>Created: {new Date(run.created_at).toLocaleString()}</span>
+          <span>Status: DETERMINISTIC PLAN</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/runs/page.tsx
+++ b/app/runs/page.tsx
@@ -1,13 +1,95 @@
+'use client';
+
 import EmptyState from "../components/EmptyState";
+import { useStore } from "../../lib/store";
+import Link from "next/link";
 
 export default function RunsPage() {
+  const { state } = useStore();
+  const { runs, proposals, isLoaded } = state;
+
+  if (!isLoaded) {
+    return <div className="animate-pulse flex space-y-4 flex-col">
+      <div className="h-8 bg-gray-200 rounded w-1/4 mb-6"></div>
+      <div className="h-64 bg-gray-100 rounded-xl"></div>
+    </div>;
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-6">Runs</h2>
+        <EmptyState
+          title="No Run Plans"
+          description="Create a run plan from an approved proposal to see it here. Execution steps will be mapped automatically."
+        />
+      </div>
+    );
+  }
+
   return (
     <div>
       <h2 className="text-2xl font-bold text-gray-900 mb-6">Runs</h2>
-      <EmptyState
-        title="No Runs"
-        description="History of all Hub executions will be listed here, including status and logs."
-      />
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Run ID
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Proposal
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Created At
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
+                <th scope="col" className="relative px-6 py-3">
+                  <span className="sr-only">Details</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {runs.map((run) => {
+                const proposal = proposals.find(p => p.proposal_id === run.proposal_id);
+                return (
+                  <tr key={run.run_id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className="px-2 py-0.5 rounded-full bg-gray-100 text-[10px] font-mono font-bold text-gray-600">
+                        {run.run_id.substring(0, 10)}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <Link href={`/artifacts/${run.proposal_id}`} className="text-sm font-medium text-blue-600 hover:text-blue-800">
+                        {proposal?.proposal.title || run.proposal_id}
+                      </Link>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-xs text-gray-500">
+                      {new Date(run.created_at).toLocaleString()}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className="px-2 py-1 text-[10px] font-bold uppercase rounded bg-blue-50 text-blue-600 tracking-wider">
+                        {run.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      <Link href={`/runs/${run.run_id}`} className="text-blue-600 hover:text-blue-900 group flex items-center justify-end gap-1">
+                        View Plan
+                        <svg className="w-4 h-4 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                        </svg>
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,3 +32,21 @@ export const DecisionSchema = z.object({
 
 export type Decision = z.infer<typeof DecisionSchema>;
 
+export const RunPlanSchema = z.object({
+  run_id: z.string(),
+  proposal_id: z.string(),
+  created_at: z.string(),
+  status: z.literal('planned'),
+  plan: z.object({
+    objective: z.string(),
+    steps: z.array(z.string()),
+    inputs_needed: z.array(z.string()),
+    expected_outputs: z.array(z.string()),
+    risks: z.array(z.string()),
+    rollback: z.array(z.string()),
+  }),
+});
+
+export type RunPlan = z.infer<typeof RunPlanSchema>;
+
+

--- a/tests/runs-store.test.ts
+++ b/tests/runs-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Proposal, RunPlan } from '../lib/types';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value.toString();
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('Run Plan Logic (Issue #6)', () => {
+  const mockProposal: Proposal = {
+    proposal_id: 'prop_123',
+    created_at: new Date().toISOString(),
+    input: { message: 'hello' },
+    proposal: {
+      title: 'Title',
+      summary: 'Summary',
+      next_actions: ['Step A'],
+      risks: ['Risk A'],
+    },
+  };
+
+  it('correctly maps proposal to run plan', () => {
+    const run_id = 'run_testing';
+    const plan: RunPlan = {
+      run_id,
+      proposal_id: mockProposal.proposal_id,
+      created_at: new Date().toISOString(),
+      status: 'planned',
+      plan: {
+        objective: mockProposal.proposal.title,
+        steps: mockProposal.proposal.next_actions,
+        inputs_needed: ['Operator approval status'],
+        expected_outputs: ['System state reflecting proposal updates'],
+        risks: mockProposal.proposal.risks,
+        rollback: ['Revert state change via manual override']
+      }
+    };
+
+    expect(plan.plan.objective).toBe(mockProposal.proposal.title);
+    expect(plan.plan.steps).toContain('Step A');
+    expect(plan.plan.risks).toContain('Risk A');
+  });
+
+  it('serializes runs to localStorage', () => {
+    const run = { run_id: 'run_1', status: 'planned' };
+    localStorage.setItem('diviora.runs.v1', JSON.stringify([run]));
+    expect(localStorage.getItem('diviora.runs.v1')).toBe(JSON.stringify([run]));
+  });
+});

--- a/tests/runs-ui.test.tsx
+++ b/tests/runs-ui.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ArtifactDetailPage from '../app/artifacts/[proposal_id]/page';
+import { Proposal, Decision } from '../lib/types';
+import { StoreProvider } from '../lib/store';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+
+// Mock navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ proposal_id: 'prop_999' }),
+  useRouter: () => ({ 
+    back: vi.fn(),
+    push: vi.fn(),
+  }),
+}));
+
+describe('Proposal Detail -> Runs Integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const renderWithStore = (ui: React.ReactElement) => {
+    return render(<StoreProvider>{ui}</StoreProvider>);
+  };
+
+  const mockProposal: Proposal = {
+    proposal_id: 'prop_999',
+    created_at: new Date().toISOString(),
+    input: { message: 'hello' },
+    proposal: {
+      title: 'Run Gating Test',
+      summary: 'Summary',
+      next_actions: ['Action'],
+      risks: ['Risk'],
+    },
+  };
+
+  it('disables "Create Run Plan" if not approved', async () => {
+    window.localStorage.setItem('diviora.proposals.v1', JSON.stringify([mockProposal]));
+
+    renderWithStore(<ArtifactDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Run Gating Test')).toBeInTheDocument();
+    });
+
+    const runBtn = screen.getByText(/Create Run Plan/i);
+    expect(runBtn).toBeDisabled();
+  });
+
+  it('enables "Create Run Plan" after approval', async () => {
+    const approvedDecision: Decision = {
+      decision_id: 'dec_999',
+      proposal_id: 'prop_999',
+      status: 'approved',
+      decided_at: new Date().toISOString(),
+    };
+
+    window.localStorage.setItem('diviora.proposals.v1', JSON.stringify([mockProposal]));
+    window.localStorage.setItem('diviora.decisions.v1', JSON.stringify([approvedDecision]));
+
+    renderWithStore(<ArtifactDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Create Run Plan/i)).not.toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #6

## Scope Implemented
- ✅ **Runs Store**: Implemented `diviora.runs.v1` store with Zod validation.
- ✅ **Approval Gating**: Enforced that only **APPROVED** proposals can generate a run plan.
- ✅ **Run Plan UI**: Added "Create Run Plan" button on proposal details with status-aware gating.
- ✅ **Plan Artifact**: Implemented deterministic generation of Objective, Steps, Risks, and Rollback from proposal fields.
- ✅ **Run Details**: Comprehensive detail page for run plans with technical breakdowns and JSON export.

## How to Test
1. Compile a proposal.
2. Observe "Create Run Plan" is disabled.
3. Approve the proposal.
4. Click **Create Run Plan**; verify redirect to the new plan.
5. Go to the **Runs** tab; verify the plan is listed.
6. Refresh; verify data persistence via localStorage.

## Validation
- Lint: PASS
- Typecheck: PASS
- Test: PASS (19 tests)
- Build: PASS